### PR TITLE
Support providing custom root directory

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -89,7 +89,7 @@ module.exports.compileFromFile = function (input) {
 		// Resolve an input.
 		absolutePath = (function () {
 			// Initialize the current root.
-			var currentRoot = path.dirname(require.main.filename),
+			var currentRoot = module.exports.options.rootDir,
 				// Initialize the directories.
 				directories = module.exports.options.directories,
 				// Initialize the directory path.
@@ -163,6 +163,8 @@ module.exports.compileFromString = function (input) {
  * Each option.
  */
 module.exports.options = {
+	//Root directory where to look for views directory
+	rootDir: path.dirname(require.main.filename),
 	// The template directories.
 	directories: ['views', '.'],
 	// Indicates if templates are cached.


### PR DESCRIPTION
Make the root directory where to look for the views folders as part of options.  This change would allow caller to set the root directory other than current process directory.  The default for this option of rootDir is current script directory.
